### PR TITLE
Dock / status bar rochade

### DIFF
--- a/Brightness/Brightness.xcodeproj/project.pbxproj
+++ b/Brightness/Brightness.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 				TargetAttributes = {
 					0A9F2FBF1AA3CAB100F6778A = {
 						CreatedOnToolsVersion = 6.1.1;
+						DevelopmentTeam = 9294MV26ES;
 						SystemCapabilities = {
 							com.apple.Sandbox = {
 								enabled = 1;
@@ -365,6 +366,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Brightness/Brightness.entitlements;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = 9294MV26ES;
 				INFOPLIST_FILE = Brightness/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "initech.$(PRODUCT_NAME:rfc1034identifier)";

--- a/Brightness/Brightness/AppDelegate.m
+++ b/Brightness/Brightness/AppDelegate.m
@@ -22,7 +22,7 @@
     self.brightCtrl = [[BrightnessController alloc] init];
     
     [self.brightCtrl start];
-    NSTimer * timer = [NSTimer timerWithTimeInterval:1.0 target:self.brightCtrl selector:@selector(refresh) userInfo:nil repeats:YES];
+    NSTimer * timer = [NSTimer timerWithTimeInterval:0.1 target:self.brightCtrl selector:@selector(refresh) userInfo:nil repeats:YES];
     NSRunLoop * mainLoop = [NSRunLoop mainRunLoop];
     [mainLoop addTimer:timer forMode:NSRunLoopCommonModes];
     
@@ -42,15 +42,15 @@
     
     self.appNapPreventionActivity = [[NSProcessInfo processInfo] beginActivityWithOptions:NSActivityUserInitiated reason:@"Prevent app nap from pausing brightness sync."];
     
-    /*
+    
      
      //Status Bar
-     
+    
     self.statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
     [self.statusItem setMenu:self.statusMenu];
-    [self.statusItem setTitle:@"My App"];
+    [self.statusItem setTitle:@"☀"];
     [self.statusItem setHighlightMode:YES];
-    */
+    
 }
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification {

--- a/Brightness/Brightness/Base.lproj/Main.storyboard
+++ b/Brightness/Brightness/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
     </dependencies>
     <scenes>
         <!--Application-->
@@ -649,14 +650,11 @@
                 <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
                 <menu title="Status Menu" id="hPw-r7-e2G">
                     <items>
-                        <menuItem title="Item 1" id="yCK-wv-ijb">
+                        <menuItem title="Quit " id="yCK-wv-ijb">
                             <modifierMask key="keyEquivalentModifierMask"/>
-                        </menuItem>
-                        <menuItem title="Item 2" id="fmi-Vh-1MP">
-                            <modifierMask key="keyEquivalentModifierMask"/>
-                        </menuItem>
-                        <menuItem title="Item 3" id="mjc-mG-MF6">
-                            <modifierMask key="keyEquivalentModifierMask"/>
+                            <connections>
+                                <action selector="terminate:" target="hnw-xV-0zn" id="NFT-qk-LCk"/>
+                            </connections>
                         </menuItem>
                     </items>
                     <connections>

--- a/Brightness/Brightness/Info.plist
+++ b/Brightness/Brightness/Info.plist
@@ -25,7 +25,7 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>
-	<false/>
+	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright © 2015 Kevin. All rights reserved.</string>
 	<key>NSMainStoryboardFile</key>

--- a/README.md
+++ b/README.md
@@ -23,10 +23,8 @@ How it works:
 
 Some ideas for improvements:
   * Rewrite it in Swift, Duh.
-  * increase the refresh rate from 1hz, make it user-settable.
   * Make it compatible with apple thunderbolt displays. (Basically, detect when the display can already control its own brightness and turn off the syncing.)
   * Add a Menu Bar widget for controlling brightness. I haven't needed this, because the keyboard (including USB keyboards) have buttons for controlling internal brightness, which is then synced to the external.
-  * Turn off the dock icon. This is easy, but not a good idea until there is a proper menu bar UI.
   * Incorporate pretty much all the good ideas from F.lux, but open source! Why not?
   * Debug the occasional crashes. Clean up the code.
   * Rewrite the code in swift. Maybe rewrite the code, period. I don't pretend that it's very good as it is.


### PR DESCRIPTION
**Changes**
- Removed permanent Dock Icon
- Re-enabled Menu Bar Menu, which now uses the `☀` symbol as an icon and holds a `Quit` action. I consider this is as a complete MVP UI. 
- Cranked up the sync-rate to .1s, which might affect CPU usage negatively, but it's still fine for me personally.

**Please be aware**
- I'm not a coder
- I have no idea what I'm doing `¯\_(ツ)_/¯`
- No prior experience in Objective-C nor macOS development